### PR TITLE
fix(theme-builder): not loading proper file

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ material-tools -d ./output -m list
 ### NodeJS usage
 
 ```js
+'use strict';
+
 const MaterialTools = require('angular-material-tools');
 
 let tools = new MaterialTools({

--- a/lib/builders/ThemeBuilder.ts
+++ b/lib/builders/ThemeBuilder.ts
@@ -15,11 +15,12 @@ export class ThemeBuilder {
   /**
    * Instantiates the Theme Builder with the specified themes and possible palettes.
    */
-  constructor(theme: MdTheme | MdTheme[], palettes?: MdPaletteDefinition) {
+  constructor(theme: MdTheme | MdTheme[], palettes?: MdPaletteDefinition, file?: string) {
 
     // Create a virtual context, to isolate the script which modifies the globals
     // to be able to mock a Browser Environment.
     this._virtualContext = new VirtualContext({
+      $$moduleName: file,
       $$interception: {
         run: this._onAngularRunFn.bind(this)
       }

--- a/typings.json
+++ b/typings.json
@@ -5,7 +5,7 @@
     "clean-css": "registry:dt/clean-css#3.4.9+20160316155526",
     "es6-promise": "registry:dt/es6-promise#0.0.0+20160614011821",
     "fs-extra": "registry:dt/fs-extra#0.0.0+20160517121359",
-    "node": "registry:dt/node#6.0.0+20160709114037",
+    "node": "registry:dt/node#6.0.0+20160801161248",
     "source-map": "registry:dt/source-map#0.0.0+20160317120654",
     "uglify-js": "registry:dt/uglify-js#2.6.1+20160316155526",
     "yargs": "registry:dt/yargs#0.0.0+20160619033636"


### PR DESCRIPTION
* Fixes the ThemeBuilder not working if the user specified a version, different from `local` and doesn't have Material installed in the `node_modules`.
* Bumps the version for the Node typings.
* Fixes the Node example throwing an error due to the lack of strict mode.