### PR TITLE
fix(theme-builder): theme builder should use main module.

### DIFF
--- a/lib/MaterialTools.ts
+++ b/lib/MaterialTools.ts
@@ -5,6 +5,7 @@ import {Utils} from './common/Utils';
 import {MaterialToolsFiles} from './resolvers/LocalResolver';
 import {DefaultConfig} from './common/DefaultConfig';
 import {MaterialBuilder, MaterialToolsOutput} from './builders/MaterialBuilder';
+import {MaterialToolsPackage} from './resolvers/PackageResolver';
 
 const fse = require('fs-extra');
 
@@ -124,7 +125,7 @@ export class MaterialTools extends MaterialBuilder {
    * Returns a promise, which resolves at finish with the given destination paths.
    */
   buildTheme(buildData?: MaterialToolsData): Promise<string[]> {
-    if (!this._themeBuilder) {
+    if (!this._themes) {
       return;
     }
 
@@ -163,6 +164,7 @@ export interface MaterialToolsData {
   files: MaterialToolsFiles;
   dependencies: any;
   license: string;
+  package: MaterialToolsPackage;
 }
 
 /** Valid options for the Material Tools */

--- a/lib/MaterialTools.ts
+++ b/lib/MaterialTools.ts
@@ -125,7 +125,7 @@ export class MaterialTools extends MaterialBuilder {
    * Returns a promise, which resolves at finish with the given destination paths.
    */
   buildTheme(buildData?: MaterialToolsData): Promise<string[]> {
-    if (!this._themes) {
+    if (!this._options.theme && !this._options.themes) {
       return;
     }
 

--- a/lib/builders/MaterialBuilder.ts
+++ b/lib/builders/MaterialBuilder.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import {MaterialToolsData, MaterialToolsOptions} from '../MaterialTools';
 import {ThemeBuilder, MdTheme} from './ThemeBuilder';
-import {PackageResolver} from '../resolvers/PackageResolver';
+import {PackageResolver, MaterialToolsPackage} from '../resolvers/PackageResolver';
 import {DependencyResolver} from '../resolvers/DependencyResolver';
 import {LocalResolver} from '../resolvers/LocalResolver';
 import {JSBuilder} from './JSBuilder';
@@ -37,7 +37,7 @@ export class MaterialBuilder {
         return {
           versionData: versionData,
           dependencies: DependencyResolver.resolve(
-            path.join(versionData.module, this._options.mainFilename),
+            this._getModuleEntry(versionData),
             this._options.modules
           )
         };
@@ -76,7 +76,7 @@ export class MaterialBuilder {
 
     // When the ThemeBuilder is not initialized and theme definitions are specified.
     if (!this._themeBuilder && this._themes) {
-      let moduleName = path.join(buildData.package.module, this._options.mainFilename);
+      let moduleName = this._getModuleEntry(buildData.package);
       this._themeBuilder = new ThemeBuilder(this._themes, this._options.palettes, moduleName);
     } else if (!this._themeBuilder) {
       return;
@@ -115,6 +115,11 @@ export class MaterialBuilder {
     lines.push(' */', '\n');
 
     return lines.join('\n');
+  }
+
+  /** Retrieves the module entry path from the specified package. */
+  private _getModuleEntry(toolsPackage: MaterialToolsPackage) {
+    return path.join(toolsPackage.module, this._options.mainFilename);
   }
 }
 

--- a/lib/builders/MaterialBuilder.ts
+++ b/lib/builders/MaterialBuilder.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import {MaterialToolsData, MaterialToolsOptions} from '../MaterialTools';
-import {ThemeBuilder, MdTheme} from './ThemeBuilder';
+import {ThemeBuilder} from './ThemeBuilder';
 import {PackageResolver, MaterialToolsPackage} from '../resolvers/PackageResolver';
 import {DependencyResolver} from '../resolvers/DependencyResolver';
 import {LocalResolver} from '../resolvers/LocalResolver';

--- a/lib/builders/MaterialBuilder.ts
+++ b/lib/builders/MaterialBuilder.ts
@@ -11,17 +11,12 @@ import {DefaultConfig} from '../common/DefaultConfig';
 export class MaterialBuilder {
 
   protected _themeBuilder: ThemeBuilder;
-  protected _themes: MdTheme[];
   protected _outputBase: string;
 
   constructor(protected _options: MaterialToolsOptions) {
     this._outputBase = path.join(this._options.destination, this._options.destinationFilename);
 
-    if (this._options.theme || this._options.themes) {
-      this._themes = []
-        .concat(this._options.theme || [])
-        .concat(this._options.themes || []);
-    }
+
   }
 
   /**
@@ -73,13 +68,15 @@ export class MaterialBuilder {
    * Outputs a static theme stylesheet, based on the specified options
    */
   _buildTheme(buildData: MaterialToolsData): MaterialToolsOutput {
-    if (!this._themes) {
+    if (!this._options.theme && !this._options.themes) {
       return;
     }
 
     if (!this._themeBuilder) {
+      let themes = (this._options.themes || []).concat(this._options.theme || []);
       let moduleName = this._getModuleEntry(buildData.package);
-      this._themeBuilder = new ThemeBuilder(this._themes, this._options.palettes, moduleName);
+
+      this._themeBuilder = new ThemeBuilder(themes, this._options.palettes, moduleName);
     }
 
     let baseSCSSFiles = DefaultConfig.baseSCSSFiles.concat(DefaultConfig.baseThemeFiles);

--- a/lib/builders/MaterialBuilder.ts
+++ b/lib/builders/MaterialBuilder.ts
@@ -73,13 +73,13 @@ export class MaterialBuilder {
    * Outputs a static theme stylesheet, based on the specified options
    */
   _buildTheme(buildData: MaterialToolsData): MaterialToolsOutput {
+    if (!this._themes) {
+      return;
+    }
 
-    // When the ThemeBuilder is not initialized and theme definitions are specified.
-    if (!this._themeBuilder && this._themes) {
+    if (!this._themeBuilder) {
       let moduleName = this._getModuleEntry(buildData.package);
       this._themeBuilder = new ThemeBuilder(this._themes, this._options.palettes, moduleName);
-    } else if (!this._themeBuilder) {
-      return;
     }
 
     let baseSCSSFiles = DefaultConfig.baseSCSSFiles.concat(DefaultConfig.baseThemeFiles);

--- a/lib/builders/ThemeBuilder.ts
+++ b/lib/builders/ThemeBuilder.ts
@@ -15,11 +15,12 @@ export class ThemeBuilder {
   /**
    * Instantiates the Theme Builder with the specified themes and possible palettes.
    */
-  constructor(theme: MdTheme | MdTheme[], palettes?: MdPaletteDefinition) {
+  constructor(theme: MdTheme | MdTheme[], palettes?: MdPaletteDefinition, mainModule?: string) {
 
     // Create a virtual context, to isolate the script which modifies the globals
     // to be able to mock a Browser Environment.
     this._virtualContext = new VirtualContext({
+      $$moduleName: mainModule,
       $$interception: {
         run: this._onAngularRunFn.bind(this)
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-material-tools",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "description": "Build tools for Angular Material",
   "main": "index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/angular/material-tools.git"
   },
   "dependencies": {
+    "angular": "^1.5.7",
+    "angular-animate": "^1.5.7",
+    "angular-aria": "^1.5.7",
     "autoprefixer": "^6.3.7",
     "clean-css": "^3.4.18",
     "cssbeautify": "^0.3.1",
@@ -31,9 +34,6 @@
     "yargs": "^4.7.1"
   },
   "devDependencies": {
-    "angular": "^1.5.7",
-    "angular-animate": "^1.5.7",
-    "angular-aria": "^1.5.7",
     "angular-material": "^1.1.0-rc.5",
     "chalk": "^1.1.3",
     "jasmine": "^2.4.1",


### PR DESCRIPTION
* The ThemeBuilder didn't use the `mainModule` file for retrieving the Angular Injector.
  This caused issues when using a downloaded version, which is not registered in the node modules.

FYI: I asked @crisbeto to submit another PR for his approach. #14 