### PR TITLE
Add options to create bundles that can be lazy loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Tool that generates custom [Angular-Material v1.x](http://github.com/angular/mat
 | ----------------------- | ----------- | -------------------------------------------------------------------------- |
 | `destination` (*)       | `string`    | Target location for the Material build.                                    |
 | `modules`               | `string[]`  | Modules that should be part of the build.<br/> All modules will be built if nothing is specified.                                                                                                           |
+| `exclude-modules`               | `string[]`  | Modules that should be excluded from the build.<br/> Use to exclude e.g. core modules when building a bundle that should get lazy-loaded.                                                                                                           |
+| `exclude-main-module`               | `boolean`  | Set to `true` to exclude the code for the Angular Material main module. Use when building a bundle that will get lazy-loaded and extend an already existing main module.                                                                 |
 | `version`               | `string`    | Version of Angular Material.<br/> If set to `local`, it will take the local installed Angular Material version from the node modules. <br/> If set to `latest`, the latest version will be downloaded.                                                           |
 | `theme`                 | `MdTheme`   | Material Theme to be used to generate a static theme stylesheet.           |
 | `themes`                | `MdTheme[]` | Multiple Material Themes, which are used to generated a static stylesheet. |

--- a/lib/MaterialTools.ts
+++ b/lib/MaterialTools.ts
@@ -171,11 +171,13 @@ export interface MaterialToolsData {
 export interface MaterialToolsOptions {
   destination?: string;
   modules?: string[];
+  excludeModules?: string[];
   version?: string;
   palettes?: MdPaletteDefinition;
   mainFilename?: string;
   cache?: string;
   destinationFilename?: string;
+  excludeMainModule?: boolean;
   /* Theming Options */
   theme?: MdTheme;
   themes?: MdTheme[];

--- a/lib/builders/JSBuilder.ts
+++ b/lib/builders/JSBuilder.ts
@@ -1,4 +1,4 @@
-import {MaterialToolsData} from '../MaterialTools';
+import {MaterialToolsData, MaterialToolsOptions} from '../MaterialTools';
 import {MaterialToolsOutput} from './MaterialBuilder';
 
 const fse = require('fs-extra');
@@ -8,9 +8,8 @@ export class JSBuilder {
   /**
    * Generates the minified and non-minified JS, as well as a source map, based on the options.
    */
-  static build(data: MaterialToolsData, filename: string): MaterialToolsOutput {
-
-    let mainModule = this._buildMainModule(data.dependencies._mainModule);
+  static build(data: MaterialToolsData, filename: string, options: MaterialToolsOptions): MaterialToolsOutput {
+    let mainModule = !options.excludeMainModule ? this._buildMainModule(data.dependencies._mainModule) : '';
     let raw = data.files.js.map(path => fse.readFileSync(path).toString()).join('\n');
     let source = [mainModule, '', raw].join('\n');
     let compressed = uglify.minify(source, {

--- a/lib/builders/MaterialBuilder.ts
+++ b/lib/builders/MaterialBuilder.ts
@@ -29,12 +29,25 @@ export class MaterialBuilder {
         // Update the resolved version, in case it was `node`.
         this._options.version = versionData.version;
 
+        let deps = DependencyResolver.resolve(
+          this._getModuleEntry(versionData),
+          this._options.modules
+        )
+
+        if (this._options.excludeModules) {
+            // Remove modules that were explicitly flagged to be excluded from the build
+            deps._flat = deps._flat.filter(dep => this._options.excludeModules.indexOf(dep) === -1)
+            deps._mainModule.dependencies = deps._mainModule.dependencies.filter(
+                dep => !this._options.excludeModules.some(
+                    // E.g. match 'animate' in 'material.core.animate'
+                    _module => dep.indexOf(_module) !== -1
+                )
+            )
+        }
+
         return {
           versionData: versionData,
-          dependencies: DependencyResolver.resolve(
-            this._getModuleEntry(versionData),
-            this._options.modules
-          )
+          dependencies: deps
         };
       })
       .then(data => {
@@ -54,7 +67,7 @@ export class MaterialBuilder {
    * Outputs the necessary JS, based on the options.
    */
   _buildJS(buildData: MaterialToolsData): MaterialToolsOutput {
-    return JSBuilder.build(buildData, `${this._outputBase}.min.js`);
+    return JSBuilder.build(buildData, `${this._outputBase}.min.js`, this._options);
   }
 
   /**

--- a/lib/cli/options.ts
+++ b/lib/cli/options.ts
@@ -53,7 +53,18 @@ export function registerOptions(yargs: any): any {
     describe: 'Directory to be used as a cache for downloaded versions.',
     default: DEFAULT_OPTIONS.cache,
     group: OPTIONAL_GROUP
-  }));
+  }))
+  .option('exclude-modules', addDefaults({
+    alias: 'em',
+    describe: 'List of modules to be excluded from the build.',
+    type: 'array',
+    group: OPTIONAL_GROUP
+  }))
+  .option('exclude-main-module', {
+    describe: 'Exclude code for main Angular Material module with list of dependencies.',
+    boolean: true,
+    group: OPTIONAL_GROUP
+  });
 
   // Logging arguments
   yargs.option('verbose', {


### PR DESCRIPTION
Add two new options `--exclude-modules` and `--exclude-main-module` that do exactly that.

The reasoning behind this is that I want to be able break up Material into a lean base bundle that contains core and a few other necessary modules for the initial app load. Accompanied by more bundles that can be lazy-loaded upon demand. These lazy-loaded bundles however must not include the core modules again.